### PR TITLE
Sam phinizy/takehome assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 tmp/**
+.DS_Store
+.idea

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 client:
-	air --build.cmd "go build -o ./bin/client ./cmd/client/main.go" --build.bin ./bin/client
+	air --build.cmd "go build -o ./bin/client ./cmd/client/main.go" --build.bin "./bin/client -folder ../tmp"
 
 server:
 	air --build.cmd "go build -o ./bin/server ./cmd/server/main.go" --build.bin ./bin/server

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -47,7 +47,7 @@ func main() {
 					return
 				}
 				log.Println("event:", event)
-				if *ignoreDotFiles && strings.HasPrefix(event.Name, ".") {
+				if *ignoreDotFiles && strings.HasPrefix(filepath.Base(event.Name), ".") {
 					log.Printf("Ignoring: %s", event.Name)
 					continue
 				}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"github.com/fsnotify/fsnotify"
 	"io/fs"
 	"log"
+	"os"
 	"path/filepath"
 	"regexp"
 	client "slai.io/takehome/pkg/client"
@@ -47,6 +49,17 @@ func main() {
 					return
 				}
 				log.Println("event:", event)
+				fileInfo, err := os.Stat(event.Name)
+				if err != nil {
+					fmt.Println(err)
+					continue
+				}
+
+				if fileInfo.IsDir() {
+					log.Printf("Ignoring: %s it's a directory", event.Name)
+					continue
+				}
+
 				if *ignoreDotFiles && strings.HasPrefix(filepath.Base(event.Name), ".") {
 					log.Printf("Ignoring: %s", event.Name)
 					continue

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"log"
 	"path/filepath"
+	"regexp"
 	client "slai.io/takehome/pkg/client"
 	"strings"
 	"syscall"
@@ -19,7 +20,6 @@ func main() {
 
 	if *folder == "" {
 		log.Println("-folder required.")
-		log.Println(*folder)
 		syscall.Exit(1)
 	}
 
@@ -38,7 +38,7 @@ func main() {
 
 	uploadChan := make(chan string, 100)
 	go c.Sync(uploadChan)
-
+	folderMatch := regexp.MustCompile(`^tmp/`)
 	go func() {
 		for {
 			select {
@@ -53,7 +53,7 @@ func main() {
 				}
 				if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
 					log.Printf("Sending: '%s'", event.Name)
-					uploadChan <- event.Name
+					uploadChan <- folderMatch.ReplaceAllString(event.Name, "")
 				}
 
 			case err, ok := <-watcher.Errors:

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -40,8 +40,8 @@ func main() {
 				}
 				log.Println("event:", event)
 				log.Printf("Sending: '%s'", event.Name)
-				value, err := c.Echo(event.Name)
-				log.Printf("Received: '%s'", value)
+				value, err := c.Sync(event.Name)
+				log.Printf("Received: '%t'", value)
 				if err != nil {
 					log.Fatal("Unable to send request.")
 				}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -31,6 +31,9 @@ func main() {
 	}
 	defer watcher.Close()
 
+	uploadChan := make(chan string, 100)
+	go c.Sync(uploadChan)
+
 	go func() {
 		for {
 			select {
@@ -40,11 +43,7 @@ func main() {
 				}
 				log.Println("event:", event)
 				log.Printf("Sending: '%s'", event.Name)
-				value, err := c.Sync(event.Name)
-				log.Printf("Received: '%t'", value)
-				if err != nil {
-					log.Fatal("Unable to send request.")
-				}
+				uploadChan <- event.Name
 			case err, ok := <-watcher.Errors:
 				if !ok {
 					return

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,14 +1,25 @@
 package main
 
 import (
+	"flag"
 	"log"
+	"syscall"
 	"time"
 
 	client "slai.io/takehome/pkg/client"
 )
 
 func main() {
-	log.Println("Starting client...")
+	folder := flag.String("folder", "", "Folder to parse.")
+	flag.Parse()
+
+	if *folder == "" {
+		log.Println("-folder required.")
+		log.Println(*folder)
+		syscall.Exit(1)
+	}
+
+	log.Printf("Starting client. Monitoring folder: %q", *folder)
 
 	c, err := client.NewClient("./")
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module slai.io/takehome
 go 1.18
 
 require (
+	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	golang.org/x/exp v0.0.0-20220921164117-439092de6870 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.18
 require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	golang.org/x/exp v0.0.0-20220921164117-439092de6870 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+golang.org/x/exp v0.0.0-20220921164117-439092de6870 h1:j8b6j9gzSigH28O5SjSpQSSh9lFd6f5D/q0aHjNTulc=
+golang.org/x/exp v0.0.0-20220921164117-439092de6870/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,11 @@
+github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
+github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 golang.org/x/exp v0.0.0-20220921164117-439092de6870 h1:j8b6j9gzSigH28O5SjSpQSSh9lFd6f5D/q0aHjNTulc=
 golang.org/x/exp v0.0.0-20220921164117-439092de6870/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -161,6 +161,13 @@ func (c *Client) Sync(uploads <-chan string) {
 		}
 
 		log.Printf("Received: '%t'", response.Success)
+
+		if response.Success {
+			log.Println("Successfully synced: ", response.FileName)
+		} else {
+			log.Println("Wasn't able to sync: ", response.FileName)
+		}
+
 		if err != nil {
 			log.Fatal("Unable to send request.")
 		}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,8 +1,13 @@
 package client
 
 import (
+	"bufio"
+	"encoding/base64"
 	"encoding/json"
+	"io"
 	"log"
+	"os"
+	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -113,6 +118,16 @@ func (c *Client) tx(msg []byte) error {
 	return nil
 }
 
+func openAndEncodeFile(filePath string) string {
+	f, _ := os.Open(filePath)
+
+	reader := bufio.NewReader(f)
+	content, _ := io.ReadAll(reader)
+
+	encoded := base64.StdEncoding.EncodeToString(content)
+	return encoded
+}
+
 // Request implementations
 
 func (r *Client) Sync(fileName string) (bool, error) {
@@ -123,7 +138,8 @@ func (r *Client) Sync(fileName string) (bool, error) {
 			RequestId:   requestId,
 			RequestType: string(common.Sync),
 		},
-		EncodedFile: fileName,
+		EncodedFile: openAndEncodeFile(fileName),
+		FileName:    filepath.Base(fileName),
 	}
 	payload, err := json.Marshal(request)
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -4,13 +4,11 @@ import (
 	"bufio"
 	"encoding/base64"
 	"encoding/json"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
 	"io"
 	"log"
 	"os"
-	"path/filepath"
-
-	"github.com/google/uuid"
-	"github.com/gorilla/websocket"
 	"slai.io/takehome/pkg/common"
 )
 
@@ -140,7 +138,7 @@ func (c *Client) Sync(uploads <-chan string) {
 				RequestType: string(common.Sync),
 			},
 			EncodedFile: openAndEncodeFile(upload),
-			FileName:    filepath.Base(upload),
+			FileName:    upload,
 		}
 		payload, err := json.Marshal(request)
 		if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -30,7 +30,7 @@ type Client struct {
 }
 
 func NewClient(directory string) (*Client, error) {
-	var client *Client = &Client{
+	var client = &Client{
 		Directory: directory,
 		hostURL:   hostURL,
 	}
@@ -130,11 +130,11 @@ func openAndEncodeFile(filePath string) string {
 
 // Request implementations
 
-func (r *Client) Sync(uploads <-chan string) {
+func (c *Client) Sync(uploads <-chan string) {
 	for upload := range uploads {
 		requestId := uuid.NewString()
 
-		var request *common.SyncRequest = &common.SyncRequest{
+		var request = &common.SyncRequest{
 			BaseRequest: common.BaseRequest{
 				RequestId:   requestId,
 				RequestType: string(common.Sync),
@@ -146,15 +146,15 @@ func (r *Client) Sync(uploads <-chan string) {
 		if err != nil {
 		}
 
-		r.channels[requestId] = make(chan []byte)
+		c.channels[requestId] = make(chan []byte)
 
-		err = r.tx(payload)
+		err = c.tx(payload)
 		if err != nil {
 		}
 
-		var response common.SyncResponse = common.SyncResponse{}
+		var response = common.SyncResponse{}
 
-		msg := <-r.channels[requestId]
+		msg := <-c.channels[requestId]
 		err = json.Unmarshal(msg, &response)
 		if err != nil {
 			log.Println("Unable to handle echo response: ", err)
@@ -167,10 +167,10 @@ func (r *Client) Sync(uploads <-chan string) {
 	}
 }
 
-func (r *Client) Echo(value string) (string, error) {
+func (c *Client) Echo(value string) (string, error) {
 	requestId := uuid.NewString()
 
-	var request *common.EchoRequest = &common.EchoRequest{
+	var request = &common.EchoRequest{
 		BaseRequest: common.BaseRequest{
 			RequestId:   requestId,
 			RequestType: string(common.Echo),
@@ -183,16 +183,16 @@ func (r *Client) Echo(value string) (string, error) {
 		return "", err
 	}
 
-	r.channels[requestId] = make(chan []byte)
+	c.channels[requestId] = make(chan []byte)
 
-	err = r.tx(payload)
+	err = c.tx(payload)
 	if err != nil {
 		return "", err
 	}
 
-	var response common.EchoResponse = common.EchoResponse{}
+	var response = common.EchoResponse{}
 
-	msg := <-r.channels[requestId]
+	msg := <-c.channels[requestId]
 	err = json.Unmarshal(msg, &response)
 	if err != nil {
 		log.Println("Unable to handle echo response: ", err)

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -4,6 +4,7 @@ type RequestType string
 
 const (
 	Echo RequestType = "ECHO"
+	Sync RequestType = "SYNC"
 )
 
 type BaseRequest struct {
@@ -24,4 +25,14 @@ type EchoRequest struct {
 type EchoResponse struct {
 	BaseResponse
 	Value string
+}
+
+type SyncRequest struct {
+	BaseRequest
+	EncodedFile string
+}
+
+type SyncResponse struct {
+	BaseResponse
+	Success bool
 }

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -30,9 +30,11 @@ type EchoResponse struct {
 type SyncRequest struct {
 	BaseRequest
 	EncodedFile string
+	FileName    string
 }
 
 type SyncResponse struct {
 	BaseResponse
-	Success bool
+	Success  bool
+	FileName string
 }

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -37,4 +37,5 @@ type SyncResponse struct {
 	BaseResponse
 	Success  bool
 	FileName string
+	ErrorMsg string
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -8,6 +8,37 @@ import (
 	"slai.io/takehome/pkg/common"
 )
 
+func HandleSync(msg []byte, client *Client) error {
+	log.Println("Recieved SYNC request.")
+
+	var request common.SyncRequest
+	err := json.Unmarshal(msg, &request)
+
+	if err != nil {
+		log.Fatal("Invalid SYNC request.")
+	}
+	response := common.SyncResponse{
+		BaseResponse: common.BaseResponse{
+			RequestId:   request.RequestId,
+			RequestType: request.RequestType,
+		},
+		Success: true,
+	}
+
+	responsePayload, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+
+	err = client.ws.WriteMessage(websocket.TextMessage, responsePayload)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
 func HandleEcho(msg []byte, client *Client) error {
 	log.Println("Received ECHO request.")
 

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -48,6 +48,7 @@ func processSyncRequest(fileChan <-chan FileDecodeMsg) {
 			},
 			Success:  success,
 			ErrorMsg: errMsg,
+			FileName: msg.request.FileName,
 		}
 
 		responsePayload, err := json.Marshal(response)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -57,6 +57,9 @@ func handleMessage(w http.ResponseWriter, r *http.Request) {
 		switch request.RequestType {
 		case string(common.Echo):
 			go HandleEcho(msg, &client)
+		case string(common.Sync):
+			go HandleSync(msg, &client)
+
 		}
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,8 +29,7 @@ var wg sync.WaitGroup
 
 func handleMessage(w http.ResponseWriter, r *http.Request,
 	outputFolder string,
-	fileChan chan FileDecodeMsg,
-	responseChan chan SyncRespWithClient) {
+	fileChan chan FileDecodeMsg) {
 
 	upgrader.CheckOrigin = func(r *http.Request) bool { return true }
 	c, err := upgrader.Upgrade(w, r, nil)
@@ -68,16 +67,15 @@ func handleMessage(w http.ResponseWriter, r *http.Request,
 		case string(common.Echo):
 			go HandleEcho(msg, &client)
 		case string(common.Sync):
-			go HandleSync(msg, &client, outputFolder, fileChan, responseChan)
+			go HandleSync(msg, &client, outputFolder, fileChan)
 
 		}
 	}
 }
 
-func handlerWrapper(outputFolder string, fileChan chan FileDecodeMsg,
-	responseChan chan SyncRespWithClient) http.HandlerFunc {
+func handlerWrapper(outputFolder string, fileChan chan FileDecodeMsg) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		handleMessage(w, r, outputFolder, fileChan, responseChan)
+		handleMessage(w, r, outputFolder, fileChan)
 	}
 }
 
@@ -94,10 +92,8 @@ func StartServer() {
 	flag.Parse()
 
 	fileChan := make(chan FileDecodeMsg, 100)
-	responseChan := make(chan SyncRespWithClient, 100)
 	go processSyncRequest(fileChan)
-	go returnSyncStatus(responseChan)
-	http.HandleFunc("/", handlerWrapper(*folder, fileChan, responseChan))
+	http.HandleFunc("/", handlerWrapper(*folder, fileChan))
 	log.Println("Starting server @", addr)
 	log.Fatal((http.ListenAndServe(addr, nil)))
 }


### PR DESCRIPTION
# What this PR does:

This PR adds in functionality to one way sync files from a client to a server using the websocket connection. 

I added in three cli args to the client:
- `-folder FOLDER_NAME`: This is the folder to monitor.
- `-recursive`: If passed then recursively add the directory. It has a bug that it doesn't recreate the recursive folder structure on the server. If I've got more time I'll add that this afternoon.
- `-ignore-dot-files`: Defaults to True. If False is passed it'll sync files like `.DS_Store`

I added a `-folder` argument to the server, the server will write all files to this folder. 


# How to use:

1. Run the server: `go run ./cmd/server/main.go -folder server_tmp`
2. Run the client: `go run ./cmd/client/main.go -folder tmp -ignore-dot-files -recursive`

Drag and drop files into the client folder and they should arrive in the server folder.

## Overall structure

### Client Side
The client uses `fsnotify` to get notifications of file changes. For each change it looks to see:

1. Was the file created or modified.
2. If we're ignoring files does it start with a `.` 

As long as those are okay it'll add it to the `uploadChan` channel which async then encodes and sends the file to the server.


### Server Side
It receives the events. If it's an echo message it just echos a response back. If it's a sync message then it adds the message to the `filesChan`. The function on the `filesChan` tries to decode the file, if it does then it writes it to disk in the location indicated by the `-folder` arg and sends back a message that the file was successfully written.


## Outstanding Issues:

### Receiving files in order.

The client is currently async, as is the server. However the server using a single worker thread to process the files. This is because order could be important if you're making multiple changes to a file you'll want them to be done in order on the server. 

For example if you're copying over the latest Factorio `.dmg` to test and also some random text files they should all upload fine however you won't get a confirmation on the later files until the server has process the large Factorio file.

### Large Files
This handled random ISOs and .dmgs I threw at it, but in a prod env I'd obviously want to break up the files into chunks and send them over piece by piece. That however seemed out of the scope of this exercise.

### Server folder structure isn't recursive
~Currently the server isn't recreating the recursive folder structure. It would be easy to do but I had hit a few hours and wanted to adhere to the spirit of the exercise. If I've got time I'll add it later.~

Update: It's recursive but doesn't currently handle new folders being created.

### Ignore doesn't ignore dirs with a .dot
Just realized this as I was writing this up. I'll add it in this afternoon if I've got some time.

### I can't spell received
Thank god for spell check or you'd be seeing recieved everywhere. 


## Other things
This was really fun! Having not really done anything in Go before this was interesting to do. It's a really great language. Things like the channels etc are really amazing. Coming at this from predominately having programmed Python lately I was dreading the async stuff as that's a pain in Python. This made it easy! 

Hopefully my code was idiomatic enough. I wasn't 100% sure the best way to pass channels around. If i were to refactor I'd probably have a struct of channels just to make it easier. 
